### PR TITLE
Handling for errors described in #3 #4 and #5

### DIFF
--- a/api/src/main/java/com/quadient/dataservices/exceptions/CreditBalanceException.java
+++ b/api/src/main/java/com/quadient/dataservices/exceptions/CreditBalanceException.java
@@ -1,0 +1,15 @@
+package com.quadient.dataservices.exceptions;
+
+/**
+ * {@link HttpResponseException} used to communicate that the user was denied a
+ * request because of a credit balance overrun.
+ */
+public class CreditBalanceException extends HttpResponseExceptionImpl {
+
+    private static final long serialVersionUID = 1L;
+
+    public CreditBalanceException(int statusCode, String reason, String response) {
+        super(statusCode, reason, response);
+    }
+
+}

--- a/api/src/main/java/com/quadient/dataservices/exceptions/RequestTooLargeException.java
+++ b/api/src/main/java/com/quadient/dataservices/exceptions/RequestTooLargeException.java
@@ -1,0 +1,14 @@
+package com.quadient.dataservices.exceptions;
+
+/**
+ * Specialized exception type used to communicate that the request payload is
+ * too large.
+ */
+public class RequestTooLargeException extends HttpResponseExceptionImpl {
+
+    private static final long serialVersionUID = 1L;
+
+    public RequestTooLargeException(int statusCode, String reason, String response) {
+        super(statusCode, reason, response);
+    }
+}

--- a/jersey/src/main/java/com/quadient/dataservices/impl/JerseyServiceCaller.java
+++ b/jersey/src/main/java/com/quadient/dataservices/impl/JerseyServiceCaller.java
@@ -139,6 +139,7 @@ abstract class JerseyServiceCaller implements ServiceCaller, AccessTokenProvider
                         // Bad gateway (rare, but could be a very short-lived issue, retry)
                         sleep(attemptNo * 180);
                     case 500:
+                    case 504:
                         sleep(attemptNo * 20);
                         logger.warn("Failed with HTTP {} (attempt no. {}), but retrying. Response: {}", statusCode,
                                 attemptNo, responseString);

--- a/jersey/src/main/java/com/quadient/dataservices/impl/JerseyServiceCaller.java
+++ b/jersey/src/main/java/com/quadient/dataservices/impl/JerseyServiceCaller.java
@@ -29,6 +29,8 @@ import com.quadient.dataservices.api.Request;
 import com.quadient.dataservices.api.Response;
 import com.quadient.dataservices.api.ServiceCaller;
 import com.quadient.dataservices.api.SuccessfulResponse;
+import com.quadient.dataservices.exceptions.CreditBalanceException;
+import com.quadient.dataservices.exceptions.RequestTooLargeException;
 import com.quadient.dataservices.impl.auth.AccessTokenProviderImpl;
 
 abstract class JerseyServiceCaller implements ServiceCaller, AccessTokenProvider {
@@ -107,7 +109,8 @@ abstract class JerseyServiceCaller implements ServiceCaller, AccessTokenProvider
             } catch (UncheckedIOException e) {
                 throw e;
             } catch (RuntimeException e) {
-                // catch unexpected exceptions, check if they're caused by IOExceptions, and if so, throw that (to be as
+                // catch unexpected exceptions, check if they're caused by IOExceptions, and if
+                // so, throw that (to be as
                 // specific as possible and conform with the advertised method signatures).
                 final Throwable cause = e.getCause();
                 if (cause instanceof IOException) {
@@ -140,6 +143,15 @@ abstract class JerseyServiceCaller implements ServiceCaller, AccessTokenProvider
                         logger.warn("Failed with HTTP {} (attempt no. {}), but retrying. Response: {}", statusCode,
                                 attemptNo, responseString);
                         return fireRequestInternal(request, attemptNo + 1);
+                    case 413:
+                        throw new RequestTooLargeException(statusCode, response.getStatusInfo().getReasonPhrase(),
+                                responseString);
+                    case 403:
+                        // check for out-of-credits scenario
+                        if (responseString.toLowerCase().contains("credit balance")) {
+                            throw new CreditBalanceException(statusCode, response.getStatusInfo().getReasonPhrase(),
+                                    responseString);
+                        }
                     default:
                         logger.warn(
                                 "Failed with HTTP {} (attempt no. {}). No retry-logic defined for this HTTP code. Response: {}",


### PR DESCRIPTION
Handles the various issues that may arise due to:

#3 : User out of credits
#4 : Request to large
#5 : Gateway timeout