### PR TITLE
Add CommandLine Parser to Sanction List Performance Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Thumbs.db
 .vs/
 .vscode/
 *.user
+*.code-workspace
 
 # dotnet build files
 obj/
@@ -25,3 +26,4 @@ project.lock.json
 
 # maven files
 target/
+

--- a/sample-app/pom.xml
+++ b/sample-app/pom.xml
@@ -38,6 +38,11 @@
 			<artifactId>slf4j-simple</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
+		<dependency>
+  			<groupId>info.picocli</groupId>
+  			<artifactId>picocli</artifactId>
+  			<version>3.9.2</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/SanctionListsPerformanceTest.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/SanctionListsPerformanceTest.java
@@ -22,6 +22,8 @@ import org.apache.metamodel.data.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import picocli.CommandLine;
+
 import com.google.common.base.Strings;
 import com.quadient.dataservices.ClientFactory;
 import com.quadient.dataservices.api.Client;
@@ -50,11 +52,19 @@ public class SanctionListsPerformanceTest extends AbstractPerformanceTest {
 
     public static void main(String[] args) throws IOException {
         
-        final Credentials credentials = CommandLineArgs.getCredentials(args);
+        final CommandLineArgs cmdLineArgs = new CommandLineArgs();
+        new CommandLine(cmdLineArgs).parse(args);
+        Credentials credentials;
+        if(cmdLineArgs.isValid()){
+            credentials = cmdLineArgs.getCredentials();
+        } else{
+            credentials = CommandLineArgs.getCredentials(cmdLineArgs.PositionalArguments);
+        }
+
         final Client client = ClientFactory.createClient(credentials);
 
         final int numThreads = 2;
-        final boolean createJob = true;
+        final boolean createJob = cmdLineArgs.isValid() ? cmdLineArgs.createJob : true;
         final int numRequests = 100;
         final int numRecordsPerRequest = 50;
 

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/SanctionListsPerformanceTest.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/SanctionListsPerformanceTest.java
@@ -49,6 +49,7 @@ public class SanctionListsPerformanceTest extends AbstractPerformanceTest {
             "https://raw.githubusercontent.com/datacleaner/DataCleaner/master/desktop/ui/src/main/resources/datacleaner-home/datastores/customers.csv";
 
     public static void main(String[] args) throws IOException {
+        
         final Credentials credentials = CommandLineArgs.getCredentials(args);
         final Client client = ClientFactory.createClient(credentials);
 

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/sanctionlistcheck/SanctionListCmdArgs.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/sanctionlistcheck/SanctionListCmdArgs.java
@@ -1,0 +1,12 @@
+package com.quadient.dataservices.samples.perftest.sanctionlistcheck;
+
+import java.util.List;
+
+import com.quadient.dataservices.samples.utils.CommandLineArgs;
+
+import picocli.CommandLine.Option;
+
+public class SanctionListCmdArgs extends CommandLineArgs {
+	@Option(names = { "-l", "--sourceList" }, description = "comma seperated list of source lists", defaultValue = "US_OFAC,EU_EEAS", split = ",")
+    public List<String> sourceLists;
+}

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/sanctionlistcheck/SanctionListsPerformanceTest.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/sanctionlistcheck/SanctionListsPerformanceTest.java
@@ -68,10 +68,10 @@ public class SanctionListsPerformanceTest extends AbstractPerformanceTest {
 
         final Client client = ClientFactory.createClient(credentials);
 
-        final int numThreads = 2;
+        final int numThreads = cmdLineArgs.numThreads;
         final boolean createJob = cmdLineArgs.isValid() ? cmdLineArgs.createJob : true;
-        final int numRequests = 100;
-        final int numRecordsPerRequest = 50;
+        final int numRequests = cmdLineArgs.numRequests;
+        final int numRecordsPerRequest = cmdLineArgs.numRecordsPerRequest;
         final MatchRequestConfiguration configuration = new MatchRequestConfiguration();        
         configuration.setSourceLists( cmdLineArgs.sourceLists.stream().map(s -> SourceList.fromValue(s)).collect(Collectors.toList()));
 

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/sanctionlistcheck/SanctionListsPerformanceTest.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/perftest/sanctionlistcheck/SanctionListsPerformanceTest.java
@@ -83,8 +83,8 @@ public class SanctionListsPerformanceTest extends AbstractPerformanceTest {
             System.exit(500);
         }
 
-        logger.info("Config:\nThreads: {}\nRequests: {}\nRecords/Request: {}\nRecords total: {}", numThreads,
-                numRequests, numRecordsPerRequest, numRecordsPerRequest * numRequests);
+        logger.info("Config:\nThreads: {}\nRequests: {}\nRecords/Request: {}\nRecords total: {}\nSourceLists: {}", numThreads,
+                numRequests, numRecordsPerRequest, numRecordsPerRequest * numRequests, String.join(",", cmdLineArgs.sourceLists));
     }
 
     private final int numRequests;

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
@@ -8,8 +8,20 @@ import com.quadient.dataservices.api.HasBaseUri;
 import com.quadient.dataservices.api.PreAuthorizedCredentials;
 import com.quadient.dataservices.api.QuadientCloudCredentials;
 import com.quadient.dataservices.api.Region;
+import picocli.CommandLine.Option;
 
 public class CommandLineArgs {
+
+    @Option(names = { "-u", "--username" }, description = "system username")
+    public String userName;
+
+    @Option(names= {"-p", "--password"}, description = "password to use")
+    public String password;
+
+    @Option(names = {"-c", "--company"} , description = "quadient cloud company")
+    public String company;
+
+    
 
     public static Credentials getCredentials(String[] args) {
         if (args.length == 4) {

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
@@ -77,6 +77,8 @@ public class CommandLineArgs {
     }
 
     public static Credentials getCredentials(String[] args) {
+        if(args == null) throw new IllegalArgumentException(
+            "Please provide the following 4 command line args: <region> <company> <username> <password>");
         if (args.length == 4) {
             final HasBaseUri region = getBaseUri(args[0]);
             final String company = args[1];

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
@@ -9,6 +9,7 @@ import com.quadient.dataservices.api.PreAuthorizedCredentials;
 import com.quadient.dataservices.api.QuadientCloudCredentials;
 import com.quadient.dataservices.api.Region;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 public class CommandLineArgs {
 
@@ -21,7 +22,50 @@ public class CommandLineArgs {
     @Option(names = {"-c", "--company"} , description = "quadient cloud company")
     public String company;
 
-    
+    @Option(names = {"-cj", "--create-job"}, description = "decide whether or not to create job while running", defaultValue = "true")
+    public Boolean createJob;
+
+    @Option(names = {"--url"}, description = "target url. overrides region")
+    public String url;
+
+    @Option(names = {"-r", "--region"}, description = "which quadient cloud region to use.")
+    public String region;
+
+    @Option(names = { "-at", "--access-token"})
+    public String accessToken;
+
+    @Parameters(index = "0..*") public String[] PositionalArguments;
+
+    public boolean isValid(){
+        return url != null;
+    }
+
+    public CommandLineArgs() {}
+
+    public Credentials getCredentials()
+    {
+        if(url == null && region == null) throw new IllegalArgumentException("--url or --region should be provided");
+        URI uri;
+        if(url != null){
+            uri = URI.create(url);
+        }else{
+            uri = getBaseUri(region).getBaseUri();
+        }
+
+        if(accessToken != null){
+            return new PreAuthorizedCredentials(uri, accessToken);
+        }
+
+        if(password == null && userName == null){
+            throw new IllegalArgumentException("if not providing accesstoken, username and password are required.");
+        }
+
+        if(company != null){
+            return new QuadientCloudCredentials(uri, company, userName, password.toCharArray());
+        }else{
+            return new AdministrativeCredentials(uri, userName, password.toCharArray());
+        }
+    }
 
     public static Credentials getCredentials(String[] args) {
         if (args.length == 4) {

--- a/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
+++ b/sample-app/src/main/java/com/quadient/dataservices/samples/utils/CommandLineArgs.java
@@ -34,6 +34,15 @@ public class CommandLineArgs {
     @Option(names = { "-at", "--access-token"})
     public String accessToken;
 
+    @Option(names = { "-tc", "--number-of-threads"}, defaultValue = "2")
+    public int numThreads;
+
+    @Option(names = { "-rpr", "--number-of-records-per-request"}, defaultValue = "50")
+    public int numRecordsPerRequest;
+
+    @Option(names = { "-rc", "--number-of-requests"}, defaultValue = "100")
+    public int numRequests;
+
     @Parameters(index = "0..*") public String[] PositionalArguments;
 
     public boolean isValid(){

--- a/swagger-model/sanction-lists-swagger.yaml
+++ b/swagger-model/sanction-lists-swagger.yaml
@@ -426,7 +426,6 @@ definitions:
     - EU_EEAS
     - US_OFAC
     - TEST
-    - PEP
   EntityType:
     type: string
     enum:

--- a/swagger-model/sanction-lists-swagger.yaml
+++ b/swagger-model/sanction-lists-swagger.yaml
@@ -170,6 +170,17 @@ definitions:
         type: string
       family_name:
         type: string
+  MatchResponsePhoneNumber:
+    type: object
+    properties:
+      phone_number:
+        type: string
+        description: |
+          The phone number associated with the record in question.
+        example: "+41446681800"
+      phone_type:
+        type: string
+        description: The phone type associated with the phone number provided.
   MatchRequestAddress:
     type: object
     allOf:
@@ -291,11 +302,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/MatchResponseAddress'
-      phone_number:
+      phone_numbers:
         type: array
         items:
-          type: string
-      email_address:
+          $ref: '#/definitions/MatchResponsePhoneNumber'
+      email_addresses:
         type: array
         items:
           type: string
@@ -415,6 +426,7 @@ definitions:
     - EU_EEAS
     - US_OFAC
     - TEST
+    - PEP
   EntityType:
     type: string
     enum:


### PR DESCRIPTION
I added real arguments to the sanction-list-perf-tests because it made it easier to script running a bunch of tests one after another.  The same model can be used for the others.